### PR TITLE
Use is_x86_feature_detected instead of CPUID if std is available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ documentation = "https://docs.rs/rdrand/0.3.0/"
 
 [dependencies]
 rand_core = { version = "0.3", default-features = false }
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
Context: https://github.com/nagisa/rust_rdrand/issues/5

The x86_64-fortanix-unknown-sgx recently gained Tier 3 support upstream.