### PR TITLE
Update `rand_core` to 0.6 (for compatibility with `rand` 0.8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdrand"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Simonas Kazlauskas <rdrand@kazlauskas.me>"]
 description = "An implementation of random number generator based on rdrand and rdseed instructions"
 keywords = ["rand", "rdrand", "rdseed", "random"]
@@ -14,7 +14,7 @@ name = "rdrand"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5.1", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Looks like an extremely straight forward upgrade.

However, since `rand_core` is part of the public API, the version of this crate is also bumped.