### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/rdrand.yml
+++ b/.github/workflows/rdrand.yml
@@ -6,7 +6,7 @@ on:
     - '*.mkd'
     - 'LICENSE'
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test:
@@ -14,12 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: [nightly, stable, 1.46.0]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # toolchain 1.46 cannot parse edition 2021, libc requires MSRV 1.63
+        rust_toolchain: [nightly, stable, 1.63]
+        # doesn't compile on Apple Silicon (issue #20)
+        os: [ubuntu-latest, windows-latest, macos-13]
         flags: ["", "--no-default-features", "--release", "--release --no-default-features"]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.rust_toolchain }}
@@ -34,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "An implementation of random number generator based on rdrand and 
 keywords = ["rand", "rdrand", "rdseed", "random"]
 license = "ISC"
 repository = "https://github.com/nagisa/rust_rdrand/"
-documentation = "https://docs.rs/rdrand/0.8.2/"
+documentation = "https://docs.rs/rdrand/0.8.3/"
 edition = "2018"
 
 [[bench]]
@@ -17,7 +17,7 @@ harness = false
 rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = ">=0.3" # allow testing with old MSRV, bench with latest release for stable
 
 [features]
 default = ["std"]


### PR DESCRIPTION
### Chores
- Update dependencies
- Bump MSRV to 1.63 to allow newer dependencies (edition 2021)
- Let dependabot update cargo and github-actions

### Not Updated
- rand (many breaking changes over the last 6 years 0.6 -> 0.9)