### PR TITLE
Add support for aarch64

### DIFF
--- a/.github/workflows/rdrand.yml
+++ b/.github/workflows/rdrand.yml
@@ -9,14 +9,13 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  test:
+  test_x86:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable, 1.86.0]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        flags: ["", "--no-default-features", "--release", "--release --no-default-features"]
+        os: [ubuntu-latest, windows-latest, macos-26-intel]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
@@ -28,10 +27,45 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=Cargo.toml ${{ matrix.flags }} -- --nocapture
-
-  bench:
+          args: --manifest-path=Cargo.toml -- --nocapture
+  test_aarch64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04-arm, windows-11-arm, macOS-latest]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            profile: minimal
+            default: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=Cargo.toml -- --nocapture
+  test_cross:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: zijiren233/cargo-cross@v1.4.2
+        with:
+          command: test
+          toolchain: nightly
+          targets: |
+            aarch64-unknown-linux-gnu
+        env:
+          QEMU_CPU: 'max'  # Ensures the emulated CPU has FEAT_RNG
+          RUSTFLAGS: '-C target-feature=+rand'
+  bench:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-26-intel, macos-latest, windows-latest, windows-11-arm ]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rdrand.yml
+++ b/.github/workflows/rdrand.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - uses: zijiren233/cargo-cross@v1.4.2
+      - uses: zijiren233/cargo-cross@30ebc6a41fafb4f7cf6af01df2387f776f6597c9
         with:
           command: test
           toolchain: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.10", default-features = false }
 
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(any(linux,openbsd,android))'.dependencies]
 libc = "0.2.185"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ harness = false
 [dependencies]
 rand_core = { version = "0.10", default-features = false }
 
+[features]
+std = []
+
 [target.'cfg(target_os = "openbsd")'.dependencies]
 libc = "0.2.185"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.10", default-features = false }
 
-[target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "android"))'.dependencies]
+[target.'cfg(target_os = "openbsd")'.dependencies]
 libc = "0.2.185"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.10", default-features = false }
 
-[target.'cfg(any(linux,openbsd,android))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "android"))'.dependencies]
 libc = "0.2.185"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ harness = false
 [dependencies]
 rand_core = { version = "0.10", default-features = false }
 
+[target.'cfg(linux)'.dependencies]
+libc = "0.2.185"
+
 [dev-dependencies]
 criterion = "0.8"
 rand = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,40 +275,13 @@ fn has_rand() -> bool {
                 && value != 0
         }
     }
-    #[cfg(target_os = "openbsd")]
-    {
-        // FIXME: Not tested.
-        const CTL_MACHDEP: c_int = 7;
-        const CPU_ID_AA64ISAR0: c_int = 2;
-
-        let mib = [CTL_MACHDEP, CPU_ID_AA64ISAR0];
-        let mut isar0: u64 = 0;
-        let mut len = core::mem::size_of_val(&isar0);
-
-        let result = unsafe {
-            libc::sysctl(
-                mib.as_ptr(),
-                mib.len() as u32,
-                &mut isar0 as *mut _ as *mut c_void,
-                &mut len,
-                core::ptr::null_mut(),
-                0,
-            )
-        };
-
-        if result == 0 {
-            // Extract the RND field (bits 60-63)
-            ((isar0 >> 60) & 0xF) >= 1
-        } else {
-            false
-        }
-    }
     #[cfg(any(
         target_os = "linux",
         target_os = "android",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "none"))]
+        target_os = "none",
+        target_os = "uefi"))]
     {
         let value: u64;
         unsafe {
@@ -329,7 +302,7 @@ fn has_rand() -> bool {
         target_os = "macos",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd",
+        target_os = "uefi",
         target_os = "none"
     )))]
     {
@@ -341,10 +314,40 @@ fn has_rand() -> bool {
 
         #[cfg(not(feature = "std"))]
         {
-            // When we can't detect the feature, assume it's unavailable unless compiling with
-            // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
-            // FIXME: Detection on iOS should be possible, but no known method is future-proof.
-            false
+            #[cfg(target_os = "openbsd")]
+            {
+                // FIXME: Not tested.
+                const CTL_MACHDEP: c_int = 7;
+                const CPU_ID_AA64ISAR0: c_int = 2;
+
+                let mib = [CTL_MACHDEP, CPU_ID_AA64ISAR0];
+                let mut isar0: u64 = 0;
+                let mut len = core::mem::size_of_val(&isar0);
+
+                let result = unsafe {
+                    libc::sysctl(
+                        mib.as_ptr(),
+                        mib.len() as u32,
+                        &mut isar0 as *mut _ as *mut c_void,
+                        &mut len,
+                        core::ptr::null_mut(),
+                        0,
+                    )
+                };
+
+                if result == 0 {
+                    // Extract the RND field (bits 60-63)
+                    ((isar0 >> 60) & 0xF) >= 1
+                } else {
+                    false
+                }
+            }
+            #[cfg(not(target_os = "openbsd"))] {
+                // When we can't detect the feature, assume it's unavailable unless compiling with
+                // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
+                // FIXME: Detection on iOS should be possible, but no known method is future-proof.
+                false
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ fn has_rand() -> bool {
         target_os = "linux",
         target_os = "android",
         target_os = "freebsd",
-        target_os = "netbsd".
+        target_os = "netbsd",
         target_os = "none"))]
     {
         let value: u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,10 +242,6 @@ fn has_rdrand(cpuid1: &arch::CpuidResult) -> bool {
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn has_rand() -> bool {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    unsafe {
-        libc::getauxval(libc::AT_HWCAP) & (1 << 14) != 0 // HWCAP_RNG bit
-    }
     #[cfg(target_os = "windows")]
     {
         // On Windows, use IsProcessorFeaturePresent
@@ -337,12 +333,11 @@ fn has_rand() -> bool {
             sysctl(mib.as_ptr(), 3, &mut value, &mut size, core::ptr::null(), 0) == 0 && value != 0
         }
     }
-
-    #[cfg(target_os = "none")]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "none"))]
     {
         let value: u64;
         unsafe {
-            // MRS is a privileged instruction (EL1), but when running on bare metal we can use it.
+            // MRS is a privileged instruction (EL1), but it's emulated on Linux.
             core::arch::asm!(
                 "mrs {0}, ID_AA64ISAR0_EL1", // feature register
                 out(reg) value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,17 +246,14 @@ fn has_rand() -> bool {
     {
         // On Windows, use IsProcessorFeaturePresent
         use core::ffi::c_int;
-
-        // PF_ARM_V8_INSTRUCTIONS_AVAILABLE = 29 (base ARMv8)
-        // PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE = 33 (ARMv8.1)
-        // For RNDR (ARMv8.5), Windows doesn't have a direct feature check
-        // So we attempt the instruction and handle the illegal instruction gracefully
         const PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE: c_int = 33;
         unsafe extern "C" {
             fn IsProcessorFeaturePresent(feature: c_int) -> i32;
         }
         // RNDR requires at least ARMv8.1, so check for atomic instructions
-        // as a minimum. Ideally Windows would have PF_ARM_V85_INSTRUCTIONS_AVAILABLE
+        // as a minimum.
+        // FIXME: May falsely report available on rare hardware. Ideally Windows would have
+        // a check specifically for RNDR.
         unsafe {
             IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != 0
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,36 +569,8 @@ impl RdRand {
 }
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-impl TryRng for RdRand {
-    type Error = ErrorCode;
-    fn try_next_u32(&mut self) -> Result<u32, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-    fn try_next_u64(&mut self) -> Result<u64, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 impl RdSeed {
     fn new() -> Result<Self, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-impl TryRng for RdSeed {
-    type Error = ErrorCode;
-    fn try_next_u32(&mut self) -> Result<u32, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-    fn try_next_u64(&mut self) -> Result<u64, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ErrorCode> {
         Err(ErrorCode::UnsupportedInstruction)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub struct RdRand(());
 /// generators.
 ///
 /// This instruction is only supported by recent architectures such as Intel Broadwell, AMD Zen,
-/// and AArch64 Armv8.5-A.
+/// and as an optional feature on AArch64 Armv8.1 and newer.
 ///
 /// This generator is not intended for general random number generation purposes and should be used
 /// to seed other generators implementing [rand_core::SeedableRng].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,12 +247,18 @@ fn has_rand() -> bool {
         // On Windows, use IsProcessorFeaturePresent
         use core::ffi::c_int;
 
-        const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
+        // PF_ARM_V8_INSTRUCTIONS_AVAILABLE = 29 (base ARMv8)
+        // PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE = 33 (ARMv8.1)
+        // For RNDR (ARMv8.5), Windows doesn't have a direct feature check
+        // So we attempt the instruction and handle the illegal instruction gracefully
+        const PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE: c_int = 33;
         unsafe extern "C" {
             fn IsProcessorFeaturePresent(feature: c_int) -> i32;
         }
+        // RNDR requires at least ARMv8.1, so check for atomic instructions
+        // as a minimum. Ideally Windows would have PF_ARM_V85_INSTRUCTIONS_AVAILABLE
         unsafe {
-            IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0
+            IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != 0
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,34 +251,33 @@ fn has_rand() -> bool {
         // On Windows, use IsProcessorFeaturePresent
         use core::ffi::c_int;
 
+        const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
+        unsafe extern "C" {
+            fn IsProcessorFeaturePresent(feature: c_int) -> i32;
+        }
         unsafe {
-            const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
-            unsafe extern "C" {
-                fn IsProcessorFeaturePresent(feature: c_int) -> i32;
-            }
             IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0
         }
     }
 
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     {
-        // On macOS, use sysctlbyname to check hw.optional.arm.FEAT_RNG
+        let mut value: u32 = 0;
+        let mut size = core::mem::size_of::<u32>();
+        #[cfg(target_os = "macos")]
+        let name = b"hw.optional.arm.FEAT_RNG\0";
+        #[cfg(target_os = "freebsd")]
+        let name = b"hw.optional.aarch64_rndr\0";
+        unsafe extern "C" {
+            fn sysctlbyname(
+                name: *const u8,
+                oldp: *mut u32,
+                oldlenp: *mut usize,
+                newp: *const core::ffi::c_void,
+                newlen: usize,
+            ) -> core::ffi::c_int;
+        }
         unsafe {
-            let mut value: u32 = 0;
-            let mut size = core::mem::size_of::<u32>();
-            #[cfg(target_os = "macos")]
-            let name = b"hw.optional.arm.FEAT_RNG\0";
-            #[cfg(target_os = "freebsd")]
-            let name = b"hw.optional.aarch64_rndr\0";
-            unsafe extern "C" {
-                fn sysctlbyname(
-                    name: *const u8,
-                    oldp: *mut u32,
-                    oldlenp: *mut usize,
-                    newp: *const core::ffi::c_void,
-                    newlen: usize,
-                ) -> core::ffi::c_int;
-            }
             sysctlbyname(name.as_ptr(), &mut value, &mut size, core::ptr::null(), 0) == 0
                 && value != 0
         }
@@ -312,29 +311,29 @@ fn has_rand() -> bool {
     }
     #[cfg(target_os = "netbsd")]
     {
+        use core::ffi::{c_int, c_uint, c_void};
+
+        unsafe extern "C" {
+            fn sysctl(
+                name: *const c_int,
+                namelen: c_uint,
+                oldp: *mut u32,
+                oldlenp: *mut usize,
+                newp: *const c_void,
+                newlen: usize,
+            ) -> c_int;
+        }
+
+        // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
+        const CTL_HW: c_int = 6;
+        const HW_OPTIONAL: c_int = 24;
+        const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
+
+        let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
+        let mut value: u32 = 0;
+        let mut size = core::mem::size_of::<u32>();
+
         unsafe {
-            use core::ffi::{c_int, c_uint, c_void};
-
-            unsafe extern "C" {
-                fn sysctl(
-                    name: *const c_int,
-                    namelen: c_uint,
-                    oldp: *mut u32,
-                    oldlenp: *mut usize,
-                    newp: *const c_void,
-                    newlen: usize,
-                ) -> c_int;
-            }
-
-            // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
-            const CTL_HW: c_int = 6;
-            const HW_OPTIONAL: c_int = 24;
-            const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
-
-            let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
-            let mut value: u32 = 0;
-            let mut size = core::mem::size_of::<u32>();
-
             sysctl(mib.as_ptr(), 3, &mut value, &mut size, core::ptr::null(), 0) == 0 && value != 0
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ fn has_rand() -> bool {
             }
             #[cfg(not(target_os = "openbsd"))] {
                 // When we can't detect the feature, assume it's unavailable unless compiling with
-                // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
+                // `-Ctarget-feature=+rand` (in which case `has_rand` is bypassed altogether).
                 // FIXME: Detection on iOS should be possible, but no known method is future-proof.
                 false
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,9 +254,7 @@ fn has_rand() -> bool {
         // as a minimum.
         // FIXME: May falsely report available on rare hardware. Ideally Windows would have
         // a check specifically for RNDR.
-        unsafe {
-            IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != 0
-        }
+        unsafe { IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != 0 }
     }
     #[cfg(any(target_os = "macos"))]
     {
@@ -305,7 +303,12 @@ fn has_rand() -> bool {
             false
         }
     }
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd". target_os = "none"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd".
+        target_os = "none"))]
     {
         let value: u64;
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,12 +568,22 @@ mod test {
 
     #[test]
     fn rdrand_works() {
-        let _status = RdRand::new().map(|mut r| {
-            r.try_next_u32().unwrap();
-            r.try_next_u64().unwrap();
-        });
-        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
-        _status.unwrap();
+        extern crate std;
+        use std::eprintln;
+        eprintln!("Checking RdRand::new()...");
+        match RdRand::new() {
+            Ok(mut r) => {
+                eprintln!("RdRand created successfully, calling try_next_u32()");
+                match r.try_next_u32() {
+                    Ok(val) => eprintln!("Got random value: {}", val),
+                    Err(e) => eprintln!("try_next_u32 failed: {:?}", e),
+                }
+            }
+            Err(e) => {
+                eprintln!("RdRand::new() failed with: {:?}", e);
+                eprintln!("This is expected on CPUs without RDRAND support");
+            }
+        }
     }
 
     #[repr(C, align(8))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,8 @@ pub struct RdRand(());
 /// This generator produces high-entropy output and is suited to seed other pseudo-random
 /// generators.
 ///
-/// This instruction is only supported by recent architectures such as Intel Broadwell and AMD Zen.
+/// This instruction is only supported by recent architectures such as Intel Broadwell, AMD Zen,
+/// and AArch64 Armv8.5-A.
 ///
 /// This generator is not intended for general random number generation purposes and should be used
 /// to seed other generators implementing [rand_core::SeedableRng].
@@ -117,6 +118,69 @@ mod arch {
         let ok = _rdseed32_step(&mut ret1) & _rdseed32_step(&mut ret2);
         *dest = (ret1 as u64) << 32 | (ret2 as u64);
         ok
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    use core::arch::asm;
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) unsafe fn rand(out: &mut u64) -> i32 {
+        let value: u64;
+        let success: u64;
+
+        unsafe {
+            asm!(
+                "mrs {0}, S3_3_C2_C4_0", // RNDR
+                "cset {1:w}, cs",  // Set w{1} to 1 if carry flag is set, else 0
+                out(reg) value,
+                lateout(reg) success,
+                options(nostack)
+            );
+        }
+        *out = value;
+        // From ARM spec:
+        // If the hardware returns a genuine random number, PSTATE.NZCV is set to 0b0000.
+        //
+        // If the instruction cannot return a genuine random number in a reasonable period of
+        // time, PSTATE.NZCV is set to 0b0100 and the data value returned is 0.
+        // So the assembly code returns 0 for success and nonzero for failure, but loop_rand expects
+        // the opposite.
+        (success == 0) as i32  // Returns 1 for success, 0 for failure
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) unsafe fn rand32(out: &mut u32) -> i32 {
+        let mut out64 = 0u64;
+        let status = unsafe { rand(&mut out64) };
+        *out = out64 as u32;
+        status
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) unsafe fn seed(out: &mut u64) -> i32 {
+        let value: u64;
+        let success: u64;
+
+        unsafe {
+            asm!(
+                "mrs {0}, S3_3_C2_C4_1", // RNDRRS
+                "cset {1:w}, cs",  // Set w{1} to 1 if carry flag is set, else 0
+                out(reg) value,
+                lateout(reg) success,
+                options(nostack)
+            );
+        }
+
+        *out = value;
+        (success == 0) as i32  // See rand() above for note on the inverted status.
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) unsafe fn seed32(out: &mut u32) -> i32 {
+        let mut out64 = 0u64;
+        let status = unsafe { seed(&mut out64) };
+        *out = out64 as u32;
+        status
     }
 }
 
@@ -177,6 +241,20 @@ fn has_rdrand(cpuid1: &arch::CpuidResult) -> bool {
     cpuid1.ecx & FLAG == FLAG
 }
 
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn has_rand() -> bool {
+    let value: u64;
+    unsafe {
+        asm!(
+            "mrs {0}, ID_AA64ISAR0_EL1", // feature register
+            out(reg) value,
+            options(nostack)
+        );
+    }
+    (value & 0xF000_0000_0000_0000) != 0
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[allow(unused_unsafe)]
 #[inline(always)]
@@ -206,6 +284,16 @@ macro_rules! is_available {
             has_rdrand(&cpuid1) && amd_family(&cpuid1) >= FIRST_GOOD_AMD_FAMILY
         } else {
             cfg!(target_feature = "rdrand") || has_rdrand(&unsafe { arch::__cpuid(1) })
+        }
+    }};
+    ("rand") => {{
+        #[cfg(target_arch="aarch64")]
+        {
+            cfg!(target_feature = "rand") || has_rand()
+        }
+        #[cfg(not(target_arch="aarch64"))]
+        {
+            unreachable!()
         }
     }};
     ("rdseed") => {{
@@ -406,6 +494,68 @@ impl_rand!(
     maxstep = arch::_rdseed32_step,
     maxty = u32
 );
+#[cfg(target_arch = "aarch64")]
+impl_rand!(
+    RdRand,
+    "rand",
+    "rdrand",
+    arch::rand32,
+    arch::rand,
+    maxstep = arch::rand,
+    maxty = u64
+);
+#[cfg(target_arch = "aarch64")]
+impl_rand!(
+    RdSeed,
+    "rand",
+    "rdseed",
+    arch::seed32,
+    arch::seed,
+    maxstep = arch::seed,
+    maxty = u64
+);
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+impl RdRand {
+    fn new() -> Result<Self, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+impl TryRng for RdRand {
+    type Error = ErrorCode;
+    fn try_next_u32(&mut self) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+    fn try_next_u64(&mut self) -> Result<u64, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+impl RdSeed {
+    fn new() -> Result<Self, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+impl TryRng for RdSeed {
+    type Error = ErrorCode;
+    fn try_next_u32(&mut self) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+    fn try_next_u64(&mut self) -> Result<u64, ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ErrorCode> {
+        Err(ErrorCode::UnsupportedInstruction)
+    }
+}
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 impl RdRand {
@@ -460,7 +610,7 @@ mod test {
             r.try_next_u32().unwrap();
             r.try_next_u64().unwrap();
         });
-        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
         _status.unwrap();
     }
 
@@ -509,7 +659,7 @@ mod test {
                 panic!("wow, we broke it? {} {} {:?}", start, end, &test_buffer[..])
             }
         });
-        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
         _status.unwrap();
     }
 
@@ -519,7 +669,7 @@ mod test {
             r.try_next_u32().unwrap();
             r.try_next_u64().unwrap();
         });
-        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
         _status.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,6 @@
 pub mod changelog;
 mod errors;
 
-#[cfg(target_arch = "aarch64")]
-use core::arch::asm;
-
 use core::hint::spin_loop;
 pub use errors::ErrorCode;
 use rand_core::{TryCryptoRng, TryRng};
@@ -133,7 +130,7 @@ mod arch {
         let success: u64;
 
         unsafe {
-            asm!(
+            core::arch::asm!(
                 "mrs {0}, S3_3_C2_C4_0", // RNDR
                 "cset {1:w}, cs",  // Set w{1} to 1 if carry flag is set, else 0
                 out(reg) value,
@@ -166,7 +163,7 @@ mod arch {
         let success: u64;
 
         unsafe {
-            asm!(
+            core::arch::asm!(
                 "mrs {0}, S3_3_C2_C4_1", // RNDRRS
                 "cset {1:w}, cs",  // Set w{1} to 1 if carry flag is set, else 0
                 out(reg) value,
@@ -283,11 +280,11 @@ fn has_rand() -> bool {
         }
 
         let mut value: u32 = 0;
-        let mut size = std::mem::size_of::<u32>();
+        let mut size = core::mem::size_of::<u32>();
         let name = b"hw.optional.arm.FEAT_RNG\0";
 
         unsafe {
-            sysctlbyname(name.as_ptr(), &mut value, &mut size, std::ptr::null(), 0) == 0
+            sysctlbyname(name.as_ptr(), &mut value, &mut size, core::ptr::null(), 0) == 0
                 && value != 0
         }
     }
@@ -321,7 +318,7 @@ fn has_rand() -> bool {
 
         let mib = [CTL_MACHDEP, CPU_ID_AA64ISAR0];
         let mut isar0: u64 = 0;
-        let mut len = std::mem::size_of_val(&isar0);
+        let mut len = core::mem::size_of_val(&isar0);
 
         let result = unsafe {
             libc::sysctl(
@@ -329,7 +326,7 @@ fn has_rand() -> bool {
                 mib.len() as u32,
                 &mut isar0 as *mut _ as *mut c_void,
                 &mut len,
-                std::ptr::null_mut(),
+                core::ptr::null_mut(),
                 0,
             )
         };
@@ -375,7 +372,7 @@ fn has_rand() -> bool {
         let value: u64;
         unsafe {
             // MRS is a privileged instruction (EL1), but when running on bare metal we can use it.
-            asm!(
+            core::arch::asm!(
                 "mrs {0}, ID_AA64ISAR0_EL1", // feature register
                 out(reg) value,
                 options(nostack)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod arch {
         // time, PSTATE.NZCV is set to 0b0100 and the data value returned is 0.
         // So the assembly code returns 0 for success and nonzero for failure, but loop_rand expects
         // the opposite.
-        (success == 0) as i32  // Returns 1 for success, 0 for failure
+        (success == 0) as i32 // Returns 1 for success, 0 for failure
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -176,7 +176,7 @@ mod arch {
         }
 
         *out = value;
-        (success == 0) as i32  // See rand() above for note on the inverted status.
+        (success == 0) as i32 // See rand() above for note on the inverted status.
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -248,15 +248,118 @@ fn has_rdrand(cpuid1: &arch::CpuidResult) -> bool {
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn has_rand() -> bool {
-    let value: u64;
+    #[cfg(linux)]
     unsafe {
-        asm!(
+        libc::getauxval(libc::AT_HWCAP) & (1 << 14) != 0 // HWCAP_RNG bit
+    }
+    #[cfg(windows)]
+    {
+        // On Windows, use IsProcessorFeaturePresent
+        use core::ffi::c_int;
+
+        extern "C" {
+            fn IsProcessorFeaturePresent(feature: c_int) -> i32;
+        }
+
+        const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
+
+        unsafe { IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0 }
+    }
+
+    #[cfg(macos)]
+    {
+        // On macOS, use sysctlbyname to check hw.optional.arm.FEAT_RNG
+        use core::ffi::CStr;
+        use core::ffi::c_int;
+
+        extern "C" {
+            fn sysctlbyname(
+                name: *const u8,
+                oldp: *mut u32,
+                oldlenp: *mut usize,
+                newp: *const std::ffi::c_void,
+                newlen: usize,
+            ) -> c_int;
+        }
+
+        let mut value: u32 = 0;
+        let mut size = std::mem::size_of::<u32>();
+        let name = b"hw.optional.arm.FEAT_RNG\0";
+
+        unsafe {
+            sysctlbyname(name.as_ptr(), &mut value, &mut size, std::ptr::null(), 0) == 0
+                && value != 0
+        }
+    }
+
+    #[cfg(freebsd)]
+    {
+        use core::ffi::c_int;
+
+        extern "C" {
+            fn sysctlbyname(
+                name: *const u8,
+                oldp: *mut u32,
+                oldlenp: *mut usize,
+                newp: *const core::ffi::c_void,
+                newlen: usize,
+            ) -> c_int;
+        }
+
+        let mut value: u32 = 0;
+        let mut size = core::mem::size_of::<u32>();
+        let name = b"hw.optional.aarch64_rndr\0";
+
+        unsafe {
+            sysctlbyname(name.as_ptr(), &mut value, &mut size, core::ptr::null(), 0) == 0
+                && value != 0
+        }
+    }
+
+    #[cfg(netbsd)]
+    {
+        use core::ffi::c_int;
+
+        extern "C" {
+            fn sysctl(
+                name: *const c_int,
+                namelen: c_uint,
+                oldp: *mut u32,
+                oldlenp: *mut usize,
+                newp: *const core::ffi::c_void,
+                newlen: usize,
+            ) -> c_int;
+        }
+
+        // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
+        const CTL_HW: c_int = 6;
+        const HW_OPTIONAL: c_int = 24;
+        const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
+
+        let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
+        let mut value: u32 = 0;
+        let mut size = core::mem::size_of::<u32>();
+
+        unsafe {
+            sysctl(mib.as_ptr(), 3, &mut value, &mut size, core::ptr::null(), 0) == 0 && value != 0
+        }
+    }
+
+    #[cfg(not(any(linux, macos, windows, freebsd, netbsd)))]
+    {
+        let value: u64;
+        unsafe {
+            // MRS is a privileged instruction (EL1), so only use it when the platform doesn't
+            // provide an alternative. When we don't have a platform, we're probably in kernel
+            // space, so we probably have the necessary privilege.
+            asm!(
             "mrs {0}, ID_AA64ISAR0_EL1", // feature register
             out(reg) value,
             options(nostack)
-        );
+            );
+        }
+        (value & 0xF000_0000_0000_0000) != 0
     }
-    (value & 0xF000_0000_0000_0000) != 0
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -291,11 +394,11 @@ macro_rules! is_available {
         }
     }};
     ("rand") => {{
-        #[cfg(target_arch="aarch64")]
+        #[cfg(target_arch = "aarch64")]
         {
             cfg!(target_feature = "rand") || has_rand()
         }
-        #[cfg(not(target_arch="aarch64"))]
+        #[cfg(not(target_arch = "aarch64"))]
         {
             unreachable!()
         }
@@ -631,7 +734,11 @@ mod test {
                 panic!("wow, we broke it? {} {} {:?}", start, end, &test_buffer[..])
             }
         });
-        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
+        #[cfg(any(
+            all(target_feature = "rand", target_arch = "aarch64"),
+            target_arch = "x86_64",
+            target_arch = "x86"
+        ))]
         _status.unwrap();
     }
 
@@ -641,7 +748,11 @@ mod test {
             r.try_next_u32().unwrap();
             r.try_next_u64().unwrap();
         });
-        #[cfg(any(all(target_feature = "rand", target_arch = "aarch64"), target_arch = "x86_64", target_arch = "x86"))]
+        #[cfg(any(
+            all(target_feature = "rand", target_arch = "aarch64"),
+            target_arch = "x86_64",
+            target_arch = "x86"
+        ))]
         _status.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,7 @@ fn has_rand() -> bool {
     {
         // When we can't detect the feature, assume it's unavailable unless compiling with
         // `-Ctarget-feature=+rdrand`.
+        // FIXME: Detection on iOS should be possible, but no known method is future-proof.
         false
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,11 +248,11 @@ fn has_rdrand(cpuid1: &arch::CpuidResult) -> bool {
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn has_rand() -> bool {
-    #[cfg(linux)]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     unsafe {
         libc::getauxval(libc::AT_HWCAP) & (1 << 14) != 0 // HWCAP_RNG bit
     }
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     {
         // On Windows, use IsProcessorFeaturePresent
         use core::ffi::c_int;
@@ -266,7 +266,7 @@ fn has_rand() -> bool {
         unsafe { IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0 }
     }
 
-    #[cfg(macos)]
+    #[cfg(target_os = "macos")]
     {
         // On macOS, use sysctlbyname to check hw.optional.arm.FEAT_RNG
         use core::ffi::CStr;
@@ -291,8 +291,7 @@ fn has_rand() -> bool {
                 && value != 0
         }
     }
-
-    #[cfg(freebsd)]
+    #[cfg(target_os = "freebsd")]
     {
         use core::ffi::c_int;
 
@@ -315,8 +314,34 @@ fn has_rand() -> bool {
                 && value != 0
         }
     }
+    #[cfg(target_os = "openbsd")]
+    {
+        const CTL_MACHDEP: c_int = 7;
+        const CPU_ID_AA64ISAR0: c_int = 2;
 
-    #[cfg(netbsd)]
+        let mib = [CTL_MACHDEP, CPU_ID_AA64ISAR0];
+        let mut isar0: u64 = 0;
+        let mut len = std::mem::size_of_val(&isar0);
+
+        let result = unsafe {
+            libc::sysctl(
+                mib.as_ptr(),
+                mib.len() as u32,
+                &mut isar0 as *mut _ as *mut c_void,
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+
+        if result == 0 {
+            // Extract the RND field (bits 60-63)
+            ((isar0 >> 60) & 0xF) >= 1
+        } else {
+            false
+        }
+    }
+    #[cfg(target_os = "netbsd")]
     {
         use core::ffi::c_int;
 
@@ -345,20 +370,31 @@ fn has_rand() -> bool {
         }
     }
 
-    #[cfg(not(any(linux, macos, windows, freebsd, netbsd)))]
+    #[cfg(target_os = "none")]
     {
         let value: u64;
         unsafe {
-            // MRS is a privileged instruction (EL1), so only use it when the platform doesn't
-            // provide an alternative. When we don't have a platform, we're probably in kernel
-            // space, so we probably have the necessary privilege.
+            // MRS is a privileged instruction (EL1), but when running on bare metal we can use it.
             asm!(
-            "mrs {0}, ID_AA64ISAR0_EL1", // feature register
-            out(reg) value,
-            options(nostack)
+                "mrs {0}, ID_AA64ISAR0_EL1", // feature register
+                out(reg) value,
+                options(nostack)
             );
         }
         (value & 0xF000_0000_0000_0000) != 0
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "windows",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "none"
+    )))]
+    {
+        false
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ fn has_rand() -> bool {
 
         unsafe {
             const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
-            extern "C" {
+            unsafe extern "C" {
                 fn IsProcessorFeaturePresent(feature: c_int) -> i32;
             }
             IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0
@@ -270,7 +270,7 @@ fn has_rand() -> bool {
             let name = b"hw.optional.arm.FEAT_RNG\0";
             #[cfg(target_os = "freebsd")]
             let name = b"hw.optional.aarch64_rndr\0";
-            extern "C" {
+            unsafe extern "C" {
                 fn sysctlbyname(
                     name: *const u8,
                     oldp: *mut u32,
@@ -315,7 +315,7 @@ fn has_rand() -> bool {
         unsafe {
             use core::ffi::{c_int, c_uint, c_void};
 
-            extern "C" {
+            unsafe extern "C" {
                 fn sysctl(
                     name: *const c_int,
                     namelen: c_uint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,10 +333,19 @@ fn has_rand() -> bool {
         target_os = "none"
     )))]
     {
-        // When we can't detect the feature, assume it's unavailable unless compiling with
-        // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
-        // FIXME: Detection on iOS should be possible, but no known method is future-proof.
-        false
+        #[cfg(feature = "std")]
+        {
+            extern crate std;
+            std::arch::is_aarch64_feature_detected!("rand")
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            // When we can't detect the feature, assume it's unavailable unless compiling with
+            // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
+            // FIXME: Detection on iOS should be possible, but no known method is future-proof.
+            false
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,20 +561,6 @@ impl TryRng for RdSeed {
     }
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-impl RdRand {
-    fn new() -> Result<Self, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-impl RdSeed {
-    fn new() -> Result<Self, ErrorCode> {
-        Err(ErrorCode::UnsupportedInstruction)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::{RdRand, RdSeed};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,6 @@ mod arch {
     }
 
     #[cfg(target_arch = "aarch64")]
-    use core::arch::asm;
-
-    #[cfg(target_arch = "aarch64")]
     pub(crate) unsafe fn rand(out: &mut u64) -> i32 {
         let value: u64;
         let success: u64;
@@ -254,59 +251,34 @@ fn has_rand() -> bool {
         // On Windows, use IsProcessorFeaturePresent
         use core::ffi::c_int;
 
-        extern "C" {
-            fn IsProcessorFeaturePresent(feature: c_int) -> i32;
+        unsafe {
+            const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
+            extern "C" {
+                fn IsProcessorFeaturePresent(feature: c_int) -> i32;
+            }
+            IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0
         }
-
-        const PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE: c_int = 34;
-
-        unsafe { IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0 }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     {
         // On macOS, use sysctlbyname to check hw.optional.arm.FEAT_RNG
-        use core::ffi::CStr;
-        use core::ffi::c_int;
-
-        extern "C" {
-            fn sysctlbyname(
-                name: *const u8,
-                oldp: *mut u32,
-                oldlenp: *mut usize,
-                newp: *const std::ffi::c_void,
-                newlen: usize,
-            ) -> c_int;
-        }
-
-        let mut value: u32 = 0;
-        let mut size = core::mem::size_of::<u32>();
-        let name = b"hw.optional.arm.FEAT_RNG\0";
-
         unsafe {
-            sysctlbyname(name.as_ptr(), &mut value, &mut size, core::ptr::null(), 0) == 0
-                && value != 0
-        }
-    }
-    #[cfg(target_os = "freebsd")]
-    {
-        use core::ffi::c_int;
-
-        extern "C" {
-            fn sysctlbyname(
-                name: *const u8,
-                oldp: *mut u32,
-                oldlenp: *mut usize,
-                newp: *const core::ffi::c_void,
-                newlen: usize,
-            ) -> c_int;
-        }
-
-        let mut value: u32 = 0;
-        let mut size = core::mem::size_of::<u32>();
-        let name = b"hw.optional.aarch64_rndr\0";
-
-        unsafe {
+            let mut value: u32 = 0;
+            let mut size = core::mem::size_of::<u32>();
+            #[cfg(target_os = "macos")]
+            let name = b"hw.optional.arm.FEAT_RNG\0";
+            #[cfg(target_os = "freebsd")]
+            let name = b"hw.optional.aarch64_rndr\0";
+            extern "C" {
+                fn sysctlbyname(
+                    name: *const u8,
+                    oldp: *mut u32,
+                    oldlenp: *mut usize,
+                    newp: *const core::ffi::c_void,
+                    newlen: usize,
+                ) -> core::ffi::c_int;
+            }
             sysctlbyname(name.as_ptr(), &mut value, &mut size, core::ptr::null(), 0) == 0
                 && value != 0
         }
@@ -340,29 +312,29 @@ fn has_rand() -> bool {
     }
     #[cfg(target_os = "netbsd")]
     {
-        use core::ffi::c_int;
-
-        extern "C" {
-            fn sysctl(
-                name: *const c_int,
-                namelen: c_uint,
-                oldp: *mut u32,
-                oldlenp: *mut usize,
-                newp: *const core::ffi::c_void,
-                newlen: usize,
-            ) -> c_int;
-        }
-
-        // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
-        const CTL_HW: c_int = 6;
-        const HW_OPTIONAL: c_int = 24;
-        const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
-
-        let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
-        let mut value: u32 = 0;
-        let mut size = core::mem::size_of::<u32>();
-
         unsafe {
+            use core::ffi::{c_int, c_uint, c_void};
+
+            extern "C" {
+                fn sysctl(
+                    name: *const c_int,
+                    namelen: c_uint,
+                    oldp: *mut u32,
+                    oldlenp: *mut usize,
+                    newp: *const c_void,
+                    newlen: usize,
+                ) -> c_int;
+            }
+
+            // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
+            const CTL_HW: c_int = 6;
+            const HW_OPTIONAL: c_int = 24;
+            const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
+
+            let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
+            let mut value: u32 = 0;
+            let mut size = core::mem::size_of::<u32>();
+
             sysctl(mib.as_ptr(), 3, &mut value, &mut size, core::ptr::null(), 0) == 0 && value != 0
         }
     }
@@ -391,6 +363,8 @@ fn has_rand() -> bool {
         target_os = "none"
     )))]
     {
+        // When we can't detect the feature, assume it's unavailable unless compiling with
+        // `-Ctarget-feature=+rdrand`.
         false
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,15 +258,11 @@ fn has_rand() -> bool {
             IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE) != 0
         }
     }
-
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    #[cfg(any(target_os = "macos"))]
     {
         let mut value: u32 = 0;
         let mut size = core::mem::size_of::<u32>();
-        #[cfg(target_os = "macos")]
         let name = b"hw.optional.arm.FEAT_RNG\0";
-        #[cfg(target_os = "freebsd")]
-        let name = b"hw.optional.aarch64_rndr\0";
         unsafe extern "C" {
             fn sysctlbyname(
                 name: *const u8,
@@ -283,6 +279,7 @@ fn has_rand() -> bool {
     }
     #[cfg(target_os = "openbsd")]
     {
+        // FIXME: Not tested.
         const CTL_MACHDEP: c_int = 7;
         const CPU_ID_AA64ISAR0: c_int = 2;
 
@@ -308,39 +305,12 @@ fn has_rand() -> bool {
             false
         }
     }
-    #[cfg(target_os = "netbsd")]
-    {
-        use core::ffi::{c_int, c_uint, c_void};
-
-        unsafe extern "C" {
-            fn sysctl(
-                name: *const c_int,
-                namelen: c_uint,
-                oldp: *mut u32,
-                oldlenp: *mut usize,
-                newp: *const c_void,
-                newlen: usize,
-            ) -> c_int;
-        }
-
-        // NetBSD uses numeric sysctl MIB for hw.optional.aarch64_rndr
-        const CTL_HW: c_int = 6;
-        const HW_OPTIONAL: c_int = 24;
-        const HW_OPTIONAL_AARCH64_RNDR: c_int = 1;
-
-        let mib = [CTL_HW, HW_OPTIONAL, HW_OPTIONAL_AARCH64_RNDR];
-        let mut value: u32 = 0;
-        let mut size = core::mem::size_of::<u32>();
-
-        unsafe {
-            sysctl(mib.as_ptr(), 3, &mut value, &mut size, core::ptr::null(), 0) == 0 && value != 0
-        }
-    }
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "none"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd". target_os = "none"))]
     {
         let value: u64;
         unsafe {
-            // MRS is a privileged instruction (EL1), but it's emulated on Linux.
+            // MRS is a privileged instruction (EL1),
+            // but it's emulated on Linux, FreeBSD and NetBSD.
             core::arch::asm!(
                 "mrs {0}, ID_AA64ISAR0_EL1", // feature register
                 out(reg) value,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,7 @@ fn has_rand() -> bool {
     )))]
     {
         // When we can't detect the feature, assume it's unavailable unless compiling with
-        // `-Ctarget-feature=+rdrand`.
+        // `-Ctarget-feature=+rdrand` (in which case `has_rand` is bypassed altogether).
         // FIXME: Detection on iOS should be possible, but no known method is future-proof.
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,12 @@
 //! </table>
 //!
 //! [Agner’s instruction tables]: http://agner.org/optimize/
+#![no_std]
 pub mod changelog;
 mod errors;
+
+#[cfg(target_arch = "aarch64")]
+use core::arch::asm;
 
 use core::hint::spin_loop;
 pub use errors::ErrorCode;


### PR DESCRIPTION
Fixes #20 

This adds support for the RNDR and RNDRRS registers on aarch64, which provide the functionality of RDRAND and RDSEED respectively on CPUs built with the optional FEAT_RNG. This support is tested through `cross`, which uses qemu, because the aarch64 CPUs currently available in GitHub Actions don't have FEAT_RNG. `std` is now an optional feature once again, but is currently only used for Aarch64 CPU feature detection on some Tier 2/3 platforms (mainly iOS and OpenBSD).